### PR TITLE
rspec/requests以下のusers_spec.rbとregistrations_spec.rbの修正

### DIFF
--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "POST /api/v1/auth" do
-    subject { post(api_v1_user_registration_path, params: params) }
+    subject(:call_api) { post(api_v1_user_registration_path, params: params) }
     let(:params) { attributes_for(:user) }
     it "ユーザー登録できる" do
       subject
       res = JSON.parse(response.body)
       expect(res["data"]["id"]).to eq(User.last.id.to_s)
       expect(res["data"]["attributes"]["name"]).to eq(User.last.name)
-      expect(response).to have_http_status(200)
+      expect(response.status).to eq 200
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
         expect(response.headers["uid"]).to be_present
         expect(response.headers["access-token"]).to be_present
         expect(response.headers["client"]).to be_present
-        expect(response).to have_http_status(200)
+        expect(response.status).to eq 200
       end
     end 
 
@@ -51,7 +51,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
         expect(response.headers["uid"]).to be_blank
         expect(response.headers["access-token"]).to be_blank
         expect(response.headers["client"]).to be_blank
-        expect(response).to have_http_status(401)
+        expect(response.status).to eq 401
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
         expect(response.headers["uid"]).to be_blank
         expect(response.headers["access-token"]).to be_blank
         expect(response.headers["client"]).to be_blank
-        expect(response).to have_http_status(401)
+        expect(response.status).to eq 401
       end
     end
 
@@ -79,7 +79,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
         expect(response.headers["uid"]).not_to be_present
         expect(response.headers["access-token"]).not_to be_present
         expect(response.headers["client"]).not_to be_present
-        expect(response).not_to have_http_status(200)
+        expect(response.status).to_not eq 200
       end
     end
   end
@@ -91,7 +91,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
         delete(destroy_api_v1_user_session_path, headers: headers)
         res = JSON.parse(response.body)
         expect(res["success"]).to be_truthy
-        expect(response).to have_http_status(200)
+        expect(response.status).to eq 200
       end
     end
   end
@@ -130,7 +130,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
         res = JSON.parse(response.body)
         expect(res["data"]["id"]).to eq(User.last.id.to_s)
         expect(res["data"]["attributes"]["name"]).to eq(User.last.name)
-        expect(response).to have_http_status(200)
+        expect(response.status).to eq 200
       end
     end
   end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "POST /api/v1/auth" do
     subject(:call_api) { post(api_v1_user_registration_path, params: params) }
+
     let(:params) { attributes_for(:user) }
+  
     it "ユーザー登録できる" do
-      subject
+      call_api
       res = JSON.parse(response.body)
       expect(res["data"]["id"]).to eq(User.last.id.to_s)
       expect(res["data"]["attributes"]["name"]).to eq(User.last.name)
@@ -14,8 +16,10 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   end
 
   describe "DELETE /api/v1/auth" do
+
     let(:user) { create(:confirmed_user) }
     let(:headers) { user.create_new_auth_token }
+
     it "ユーザー削除できる" do
       delete(api_v1_user_registration_path, headers: headers)
       res = JSON.parse(response.body)
@@ -25,13 +29,14 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   end
 
   describe "POST /api/v1/auth/sign_in" do
-    subject { post(api_v1_user_session_path, params: params) }
+    subject(:call_api) { post(api_v1_user_session_path, params: params) }
 
     context "メールアドレス、パスワードが正しく、有効化もされているとき" do
       let(:confirmed_user) { create(:confirmed_user) }
       let(:params) { { email: confirmed_user.email, password: confirmed_user.password } }
+
       it "ログインできる" do
-        subject
+        call_api
         res = JSON.parse(response.body)
         expect(response.headers["uid"]).to be_present
         expect(response.headers["access-token"]).to be_present
@@ -43,8 +48,9 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
     context "有効化はしたが、メールアドレスが正しくないとき" do
       let(:user) { create(:confirmed_user) }
       let(:params) { { email: "invalid@example.com", password: user.password } }
+
       it "ログインできない" do
-        subject
+        call_api
         res = JSON.parse(response.body)
         expect(res["success"]).to be_falsey
         expect(res["errors"]).to include("Invalid login credentials. Please try again.")
@@ -58,8 +64,9 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
     context "有効化はしたが、パスワードが正しくないとき" do
       let(:user) { create(:confirmed_user) }
       let(:params) { { email: user.email, password: "invalidpassword" } }
+
       it "ログインできない" do
-        subject
+        call_api
         res = JSON.parse(response.body)
         expect(res["success"]).to be_falsey
         expect(res["errors"]).to include("Invalid login credentials. Please try again.")
@@ -73,8 +80,9 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
     context "メールアドレス、パスワードは正しいが、有効化されていないとき" do
       let(:user) { create(:user) }
       let(:params) { { email: user.email, password: user.password } }
+
       it "ログインできない" do
-        subject
+        call_api
         res = JSON.parse(response.body)
         expect(response.headers["uid"]).not_to be_present
         expect(response.headers["access-token"]).not_to be_present
@@ -84,9 +92,11 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
     end
   end
   describe "DELETE /api/v1/auth/sign_out" do
+
     context "ユーザーがログインしているとき" do
       let(:user) { create(:confirmed_user) }
       let(:headers) { user.create_new_auth_token }
+
       it "ログアウトできる" do
         delete(destroy_api_v1_user_session_path, headers: headers)
         res = JSON.parse(response.body)
@@ -96,10 +106,12 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
     end
   end
   describe "PUT /api/v1/auth" do
+
     context "渡す値が正しいとき" do
       let(:user) { create(:confirmed_user) }
       let(:headers) { user.create_new_auth_token }
       let(:params) { {name: 'テスト太郎', profile: 'テストマンだよ', address: 'テス都', image: 'https://image_url' } }
+
       it "値を変更できる" do
         put api_v1_user_registration_path, params: params, headers: headers
         res = JSON.parse(response.body)
@@ -112,6 +124,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
     context "渡す値が正しくないとき" do
       let(:user) { create(:confirmed_user) }
       let(:params) { { id: '3' } }
+
       it "値を変更できない" do
         put api_v1_user_registration_path, params: params, headers: headers
         res = JSON.parse(response.body)
@@ -119,12 +132,14 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
         expect(res["errors"]).to include("Please submit proper account update data in request body.")
       end
     end
-  end   
+  end
 
   describe "GET /api/v1/auth/edit" do
+
     context "ユーザーがログインしているとき" do
       let(:user) { create(:confirmed_user) }
       let(:headers) { user.create_new_auth_token }
+
       it "ユーザーの情報を返す" do
         get(edit_api_v1_user_registration_path, headers: headers)
         res = JSON.parse(response.body)

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -2,14 +2,16 @@ require 'rails_helper'
 
 RSpec.describe "Api::V1::Users", type: :request do
   describe "GET /api/users/:id" do
+    subject(:call_api){ get(api_v1_user_path(user)) }
+
     let(:user) { create(:user) }
-    subject{ get(api_v1_user_path(user)) }
+
     it "ユーザーのデータを返す" do
-      subject
+      call_api
       res = JSON.parse(response.body)
       expect(res["data"]["id"]).to eq(User.last.id.to_s)
       expect(res["data"]["attributes"]["name"]).to eq(User.last.name)
-      expect(response).to have_http_status(200)
+      expect(response.status).to eq 200
     end
   end
 end


### PR DESCRIPTION
修正箇所
・subjectの引数に(:call_api)を追加
・specのレスポンスステータスコードのチェック方法の変更