### PR TITLE
store/indexのテストを実装

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8888,6 +8888,12 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "eslint-loader": "^2.1.1",
     "eslint-plugin-vue": "^4.0.0",
     "jest": "^25.2.3",
+    "lodash.clonedeep": "^4.5.0",
     "node-sass": "^4.13.1",
     "nuxt-sass-resources-loader": "^2.0.5",
     "sass-loader": "^8.0.2",

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -74,7 +74,7 @@ export const actions = {
       if (error.response && error.response.status === 401) {
         throw new Error("Bad credentials");
       }
-      throw error;
+      throw new Error("Internal Server Error");
     }
   },
 

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -1,34 +1,43 @@
 const cookieparser = process.server ? require("cookieparser") : undefined;
 
-export const state = () => {
-  return {
-    access_token: "",
-    uid: "",
-    client: "",
-    id: "",
-    isAuthenticated: false,
-  };
+export const state = () => ({
+  access_token: null,
+  client: null,
+  id: null,
+  uid: null,
+  isAuthenticated: false,
+});
+
+export const getters = {
+  access_token: (state) => state.access_token,
+  client: (state) => state.client,
+  uid: (state) => state.uid,
+  id: (state) => state.id,
+  isAuthenticated: (state) => state.isAuthenticated,
 };
+
 export const mutations = {
-  setUser(state, res) {
-    state.access_token = res.headers["access-token"];
-    state.uid = res.headers["uid"];
-    state.client = res.headers["client"];
-    state.id = res.data.data.id;
-    state.isAuthenticated = true;
-  },
-  setHeader(state, { header, auth_flag }) {
-    state.access_token = header["access-token"];
-    state.uid = header["uid"];
-    state.client = header["client"];
-    state.isAuthenticated = auth_flag;
-  },
   clearUser(state) {
     state.access_token = null;
-    state.isAuthenticated = false;
-    state.uid = null;
     state.client = null;
     state.id = null;
+    state.uid = null;
+    state.isAuthenticated = false;
+  },
+
+  setUser(state, res) {
+    state.access_token = res.headers["access-token"];
+    state.client = res.headers["client"];
+    state.id = res.data.data.id;
+    state.uid = res.headers["uid"];
+    state.isAuthenticated = true;
+  },
+
+  setHeader(state, { header, auth_flag }) {
+    state.access_token = header["access-token"];
+    state.client = header["client"];
+    state.uid = header["uid"];
+    state.isAuthenticated = auth_flag;
   }
 };
 

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -44,19 +44,17 @@ export const mutations = {
 export const actions = {
   async login({ commit }, { email, password }) {
     try {
-      await this.$axios
-        .post(`/api/v1/auth/sign_in`, {
-          email,
-          password
-        })
-        .then(res => {
-          commit("setUser", res);
-        });
+      const res = await this.$axios.post(`/api/v1/auth/sign_in`, {
+        email,
+        password
+      })
+
+      commit("setUser", res);
     } catch (error) {
       if (error.response && error.response.status === 401) {
         throw new Error("Bad credentials");
       }
-      throw error;
+      throw new Error("Internal Server Error");
     }
   },
   async logout({ commit }, { access_token, client, uid }) {

--- a/frontend/tests/store/index.spec.js
+++ b/frontend/tests/store/index.spec.js
@@ -1,10 +1,24 @@
 import Vuex from 'vuex';
+import axios from 'axios';
 import * as index from '~/store/index';
 import { createLocalVue } from '@vue/test-utils';
 import cloneDeep from 'lodash.clonedeep';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
+
+// axiosのmock
+let mockAxiosGetResult; // Axiosで発生させる戻り値
+let mockAxiosError = false; // Errorを発生させるかどうか
+jest.mock('axios', () => ({
+  post: jest.fn(() => {
+    if (mockAxiosError) {
+      return Promise.reject(mockAxiosGetResult);
+    }
+
+    return Promise.resolve(mockAxiosGetResult);
+  })
+}));
 
 describe('store/index.js', () => {
   let store;
@@ -15,30 +29,6 @@ describe('store/index.js', () => {
   })
 
   describe('mutaions', () => {
-    it('setUserの正常系', () => {
-      expect(store.getters.access_token).toBeNull();
-      expect(store.getters.client).toBeNull();
-      expect(store.getters.id).toBeNull();
-      expect(store.getters.uid).toBeNull();
-      expect(store.getters.isAuthenticated).toBeFalsy();
-
-      const res = {
-        headers: {
-          "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
-          uid: "hoge@example.com",
-          client: "NQqnvItfl_4F9V_l2gzIla",
-        },
-        data: { data: { id: "1" } }
-      };
-      store.commit('setUser', res);
-
-      expect(store.getters.access_token).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
-      expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
-      expect(store.getters.id).toBe("1");
-      expect(store.getters.uid).toBe("hoge@example.com");
-      expect(store.getters.isAuthenticated).toBeTruthy();
-    }),
-
     it('setHeaderの正常系', () => {
       expect(store.getters.access_token).toBeNull();
       expect(store.getters.client).toBeNull();
@@ -59,7 +49,7 @@ describe('store/index.js', () => {
       expect(store.getters.isAuthenticated).toBeTruthy();
     })
 
-    it('clearUserの正常系', () => {
+    it('setUserとclearUserの正常系', () => {
       expect(store.getters.access_token).toBeNull();
       expect(store.getters.client).toBeNull();
       expect(store.getters.id).toBeNull();
@@ -88,6 +78,58 @@ describe('store/index.js', () => {
       expect(store.getters.id).toBeNull();
       expect(store.getters.uid).toBeNull();
       expect(store.getters.isAuthenticated).toBeFalsy();
+    })
+  })
+
+  describe('actions', () => {
+
+    beforeEach(() => {
+      store.$axios = axios; // @nuxtjs/axiosの代わりにaxiosを注入
+    });
+
+    it('loginできる(正常系)', async () => {
+      mockAxiosGetResult = {
+        headers: {
+          "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
+          uid: "hoge@example.com",
+          client: "NQqnvItfl_4F9V_l2gzIla",
+        },
+        data: { data: { id: "1" } }
+      };
+
+      await store.dispatch('login', { email: 'hoge@example.com', password: 'password'});
+
+      expect(store.getters.access_token).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
+      expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
+      expect(store.getters.id).toBe("1");
+      expect(store.getters.uid).toBe("hoge@example.com");
+      expect(store.getters.isAuthenticated).toBeTruthy();
+    })
+
+    it('loginできない(異常系:Internal Server Error)', async () => {
+      mockAxiosError = true;
+      mockAxiosGetResult= {
+        reponse: {
+          status: 500
+        }
+      };
+
+      await expect(
+        store.dispatch('login', { email: 'hoge@example.com', password: 'password'})
+      ).rejects.toThrow("Internal Server Error");
+    })
+
+    it('loginできない(異常系:Bad credentials)', async () => {
+      mockAxiosError = true;
+      mockAxiosGetResult= {
+        response: {
+          status: 401
+        }
+      };
+
+      await expect(
+        store.dispatch('login', { email: 'hoge@example.com', password: 'password'})
+      ).rejects.toThrow("Bad credentials");
     })
   })
 });

--- a/frontend/tests/store/index.spec.js
+++ b/frontend/tests/store/index.spec.js
@@ -1,0 +1,93 @@
+import Vuex from 'vuex';
+import * as index from '~/store/index';
+import { createLocalVue } from '@vue/test-utils';
+import cloneDeep from 'lodash.clonedeep';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('store/index.js', () => {
+  let store;
+
+  // mockのVueインスタンスを生成
+  beforeEach(() => {
+    store = new Vuex.Store(cloneDeep(index))
+  })
+
+  describe('mutaions', () => {
+    it('setUserの正常系', () => {
+      expect(store.getters.access_token).toBeNull();
+      expect(store.getters.client).toBeNull();
+      expect(store.getters.id).toBeNull();
+      expect(store.getters.uid).toBeNull();
+      expect(store.getters.isAuthenticated).toBeFalsy();
+
+      const res = {
+        headers: {
+          "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
+          uid: "hoge@example.com",
+          client: "NQqnvItfl_4F9V_l2gzIla",
+        },
+        data: { data: { id: "1" } }
+      };
+      store.commit('setUser', res);
+
+      expect(store.getters.access_token).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
+      expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
+      expect(store.getters.id).toBe("1");
+      expect(store.getters.uid).toBe("hoge@example.com");
+      expect(store.getters.isAuthenticated).toBeTruthy();
+    }),
+
+    it('setHeaderの正常系', () => {
+      expect(store.getters.access_token).toBeNull();
+      expect(store.getters.client).toBeNull();
+      expect(store.getters.uid).toBeNull();
+      expect(store.getters.isAuthenticated).toBeFalsy();
+
+      const parsedCookie = {
+        "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
+        uid: "hoge@example.com",
+        client: "NQqnvItfl_4F9V_l2gzIla",
+      };
+
+      store.commit('setHeader', { header: parsedCookie, auth_flag: true });
+
+      expect(store.getters.access_token).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
+      expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
+      expect(store.getters.uid).toBe("hoge@example.com");
+      expect(store.getters.isAuthenticated).toBeTruthy();
+    })
+
+    it('clearUserの正常系', () => {
+      expect(store.getters.access_token).toBeNull();
+      expect(store.getters.client).toBeNull();
+      expect(store.getters.id).toBeNull();
+      expect(store.getters.uid).toBeNull();
+      expect(store.getters.isAuthenticated).toBeFalsy();
+
+      const res = {
+        headers: {
+          "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
+          uid: "hoge@example.com",
+          client: "NQqnvItfl_4F9V_l2gzIla",
+        },
+        data: { data: { id: "1" } }
+      };
+      store.commit('setUser', res);
+
+      expect(store.getters.access_token).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
+      expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
+      expect(store.getters.id).toBe("1");
+      expect(store.getters.uid).toBe("hoge@example.com");
+      expect(store.getters.isAuthenticated).toBeTruthy();
+
+      store.commit('clearUser');
+      expect(store.getters.access_token).toBeNull();
+      expect(store.getters.client).toBeNull();
+      expect(store.getters.id).toBeNull();
+      expect(store.getters.uid).toBeNull();
+      expect(store.getters.isAuthenticated).toBeFalsy();
+    })
+  })
+});


### PR DESCRIPTION
# やったこと
- store/index.jsのテスト
  - mutationのテスト
  - actionのテスト(login, logout) 
- store/index.jsの機能追加とコードの掃除
  - actionsのlogin, logoutの401以外のエラーをInternal Server Errorに変更。
``` js 
// before
return errror
// after
throw new Error("Internal Server Error");
```
  - gettersがなかったので追加した。(testで必要なため、testではgettersの値は読み取ることができるが、stateの値を読み取ることができなかった。)
  - stateやmutationのkey名をアルファベット順に並び替えた。

## 重要
Vuexのテストのために新しいライブラリ導入した。
`npm i`をしてください。

ライブラリ名："lodash.clonedeep"
ディープコピーをするのに必要らしい。
[シャローコピー(shallow copy)とディープコピー(deep copy)の違い](https://nansystem.com/shallow-copy-vs-deep-copy/)

## やってないこと
- nuxtServerInitのテスト