### PR TITLE
認証系のstoreをauthenticationへ分離

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -3,7 +3,8 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: [
     '<rootDir>/components/**/*.vue',
-    '<rootDir>/pages/**/*.vue'
+    '<rootDir>/pages/**/*.vue',
+    '<rootDir>/store/**/*.js'
   ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -13,7 +13,7 @@
           </v-list-item>
         </nuxt-link>
 
-        <nuxt-link to="/user/login" v-if="!$store.state.isAuthenticated">
+        <nuxt-link to="/user/login" v-if="!isAuthenticated">
           <v-list-item link>
             <v-list-item-action>
               <v-icon>mdi-account-arrow-right</v-icon>
@@ -27,7 +27,7 @@
         <v-list-item
           link
           @click="logout"
-          v-if="$store.state.isAuthenticated"
+          v-if="isAuthenticated"
         >
           <v-list-item-action>
             <v-icon>mdi-account-cancel-outline</v-icon>
@@ -37,7 +37,7 @@
           </v-list-item-content>
         </v-list-item>
 
-        <nuxt-link to="/user/sign_up" v-if="!$store.state.isAuthenticated">
+        <nuxt-link to="/user/sign_up" v-if="!isAuthenticated">
           <v-list-item link>
             <v-list-item-action>
               <v-icon>mdi-account-plus</v-icon>
@@ -48,7 +48,7 @@
           </v-list-item>
         </nuxt-link>
 
-        <nuxt-link to="/user/1" v-if="$store.state.isAuthenticated">
+        <nuxt-link to="/user/1" v-if="isAuthenticated">
           <v-list-item link>
             <v-list-item-action>
               <v-icon>mdi-account-details</v-icon>
@@ -70,7 +70,7 @@
           </v-list-item>
         </nuxt-link>
 
-        <nuxt-link to="/memos/write" v-if="$store.state.isAuthenticated">
+        <nuxt-link to="/memos/write" v-if="isAuthenticated">
           <v-list-item link>
             <v-list-item-action>
               <v-icon>mdi-border-color</v-icon>
@@ -117,26 +117,22 @@
 </template>
 
 <script>
-const Cookie = process.client ? require("js-cookie") : undefined;
-
 export default {
-  props: {
-    source: String
-  },
   data: () => ({
     drawer: null
   }),
+
+  computed: {
+    isAuthenticated() {
+      return this.$store.getters["authentication/isAuthenticated"]
+    }
+  },
+
   methods: {
     async logout() {
       try {
-        await this.$store.dispatch("logout", {
-          access_token: Cookie.get("access-token"),
-          client: Cookie.get("client"),
-          uid: Cookie.get("uid")
-        });
-        Cookie.remove("access-token");
-        Cookie.remove("client");
-        Cookie.remove("uid");
+        await this.$store.dispatch("authentication/logout");
+
         this.$router.push(`/user/login`);
       } catch (e) {
         console.error(e);

--- a/frontend/middleware/authenticated.js
+++ b/frontend/middleware/authenticated.js
@@ -1,6 +1,6 @@
 export default function ({ store, redirect }) {
     // ユーザーが認証されていないとき
-    if(!store.state.isAuthenticated) {
-        return redirect('/user/login');
-    }
+  if (!store.getters["authentication/isAuthenticated"]) {
+    return redirect('/user/login');
+  }
 }

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <div>
-      <p>{{ uid }} : {{ access_token }} : {{ isAuthenticated }}</p>
+      <p>{{ uid }} : {{ accessToken }} : {{ isAuthenticated }}</p>
       <app-logo/>
       <h1 class="title">
         frontend
@@ -32,8 +32,8 @@ export default {
   },
 
   computed: {
-    access_token() {
-      return this.$store.getters["authentication/access_token"];
+    accessToken() {
+      return this.$store.getters["authentication/accessToken"];
     },
 
     isAuthenticated() {

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <div>
-      <p>{{ $store.state.uid }} : {{ $store.state.access_token }} : {{ $store.state.isAuthenticated }}</p>
+      <p>{{ uid }} : {{ access_token }} : {{ isAuthenticated }}</p>
       <app-logo/>
       <h1 class="title">
         frontend
@@ -24,13 +24,26 @@
 </template>
 
 <script>
-const Cookie = process.client ? require('js-cookie') : undefined
 import AppLogo from '~/components/AppLogo.vue'
 
 export default {
   components: {
     AppLogo
   },
+
+  computed: {
+    access_token() {
+      return this.$store.getters["authentication/access_token"];
+    },
+
+    isAuthenticated() {
+      return this.$store.getters["authentication/isAuthenticated"];
+    },
+
+    uid() {
+      return this.$store.getters["authentication/uid"];
+    },
+  }
 }
 </script>
 

--- a/frontend/pages/memos/write.vue
+++ b/frontend/pages/memos/write.vue
@@ -6,10 +6,6 @@
 
 <script>
 export default {
-    middleware({ store, redirect }) {
-        if(!store.state.isAuthenticated) {
-            redirect('/user/login');
-        }
-    },
+  middleware: "authenticated"
 }
 </script>

--- a/frontend/pages/user/edit/_id.vue
+++ b/frontend/pages/user/edit/_id.vue
@@ -31,8 +31,6 @@
 </template>
 
 <script>
-const Cookie = process.client ? require("js-cookie") : undefined;
-
 export default {
   data: () => ({
     showPassword: false,

--- a/frontend/pages/user/login.vue
+++ b/frontend/pages/user/login.vue
@@ -39,8 +39,6 @@
 </template>
 
 <script>
-const Cookie = process.client ? require("js-cookie") : undefined;
-
 export default {
   data: () => ({
     showPassword: false,
@@ -60,14 +58,12 @@ export default {
   methods: {
       async login(e) {
         try {
-          await this.$store.dispatch("login", {
+          await this.$store.dispatch("authentication/login", {
             email: this.email,
             password: this.password
           });
-          Cookie.set("access-token", this.$store.state.access_token);
-          Cookie.set("client", this.$store.state.client);
-          Cookie.set("uid", this.$store.state.uid);
-          this.$router.push(`/user/${this.$store.state.id}`);
+
+          this.$router.push(`/user/${this.$store.getters["authentication/id"]}`);
         } catch (e) {
           console.log(this.formError);
         }

--- a/frontend/pages/user/sign_up.vue
+++ b/frontend/pages/user/sign_up.vue
@@ -72,6 +72,7 @@ export default {
           email: this.email,
           password: this.password
         });
+
         this.$router.push(`/user/confirm`);
       } catch (error) {
         console.error(error);

--- a/frontend/plugins/axios.js
+++ b/frontend/plugins/axios.js
@@ -1,7 +1,7 @@
 export default function({ app: { $axios }, store }) {
   $axios.onRequest(config => {
-    $axios.setHeader("access-token", store.state.access_token);
-    $axios.setHeader("uid", store.state.uid);
-    $axios.setHeader("client", store.state.client);
+    $axios.setHeader("access-token", store.getters["authentication/access_token"]);
+    $axios.setHeader("uid", store.getters["authentication/uid"]);
+    $axios.setHeader("client", store.getters["authentication/client"]);
   })
 }

--- a/frontend/plugins/axios.js
+++ b/frontend/plugins/axios.js
@@ -1,6 +1,6 @@
 export default function({ app: { $axios }, store }) {
   $axios.onRequest(config => {
-    $axios.setHeader("access-token", store.getters["authentication/access_token"]);
+    $axios.setHeader("access-token", store.getters["authentication/accessToken"]);
     $axios.setHeader("uid", store.getters["authentication/uid"]);
     $axios.setHeader("client", store.getters["authentication/client"]);
   })

--- a/frontend/store/authentication.js
+++ b/frontend/store/authentication.js
@@ -54,9 +54,11 @@ export const actions = {
       commit("setUser", res);
 
       // Cookieにセット
-      Cookie.set("access-token", getters.accessToken);
-      Cookie.set("client", getters.client);
-      Cookie.set("uid", getters.uid);
+      if (Cookie !== undefined) {
+        Cookie.set("access-token", getters.accessToken);
+        Cookie.set("client", getters.client);
+        Cookie.set("uid", getters.uid);
+      }
 
     } catch (error) {
       if (error.response && error.response.status === 401) {
@@ -67,11 +69,11 @@ export const actions = {
   },
 
   // ログアウト
-  async logout ({ commit }) {
+  async logout ({ commit, getters }) {
     try {
-      const accessToken = Cookie.get("access-token");
-      const client = Cookie.get("client");
-      const uid = Cookie.get("uid");
+      const accessToken = getters.accessToken;
+      const client = getters.client;
+      const uid = getters.uid;
 
       await this.$axios.delete(
         `/api/v1/auth/sign_out`,
@@ -85,9 +87,12 @@ export const actions = {
       );
 
       commit("clearUser");
-      Cookie.remove("access-token");
-      Cookie.remove("client");
-      Cookie.remove("uid");
+
+      if (Cookie !== undefined) {
+        Cookie.remove("access-token");
+        Cookie.remove("client");
+        Cookie.remove("uid");
+      }
     } catch (error) {
       if (error.response && error.response.status === 401) {
         throw new Error("Bad credentials");

--- a/frontend/store/authentication.js
+++ b/frontend/store/authentication.js
@@ -1,0 +1,98 @@
+const Cookie = process.client ? require("js-cookie") : undefined;
+
+export const state = () => ({
+  access_token: null,
+  client: null,
+  id: null,
+  uid: null,
+  isAuthenticated: false,
+});
+
+export const getters = {
+  access_token: (state) => state.access_token,
+  client: (state) => state.client,
+  uid: (state) => state.uid,
+  id: (state) => state.id,
+  isAuthenticated: (state) => state.isAuthenticated,
+};
+
+export const mutations = {
+  clearUser (state) {
+    state.access_token = null;
+    state.client = null;
+    state.id = null;
+    state.uid = null;
+    state.isAuthenticated = false;
+  },
+
+  setUser (state, res) {
+    state.access_token = res.headers["access-token"];
+    state.client = res.headers["client"];
+    state.id = res.data.data.id;
+    state.uid = res.headers["uid"];
+    state.isAuthenticated = true;
+  },
+
+  setHeader (state, { header, auth_flag }) {
+    state.access_token = header["access-token"];
+    state.client = header["client"];
+    state.uid = header["uid"];
+    state.isAuthenticated = auth_flag;
+  }
+};
+
+export const actions = {
+
+  // ログイン
+  async login ({ commit, getters }, { email, password }) {
+    try {
+      const res = await this.$axios.post(`/api/v1/auth/sign_in`, {
+        email,
+        password
+      })
+
+      commit("setUser", res);
+
+      // Cookieにセット
+      Cookie.set("access-token", getters.access_token);
+      Cookie.set("client", getters.client);
+      Cookie.set("uid", getters.uid);
+
+    } catch (error) {
+      if (error.response && error.response.status === 401) {
+        throw new Error("Bad credentials");
+      }
+      throw new Error("Internal Server Error");
+    }
+  },
+
+  // ログアウト
+  async logout ({ commit }) {
+    try {
+      const access_token = Cookie.get("access-token");
+      const client = Cookie.get("client");
+      const uid = Cookie.get("uid");
+
+      await this.$axios.delete(
+        `/api/v1/auth/sign_out`,
+        {
+          headers: {
+            "access-token": access_token,
+            client: client,
+            uid: uid
+          }
+        }
+      );
+
+      commit("clearUser");
+      Cookie.remove("access-token");
+      Cookie.remove("client");
+      Cookie.remove("uid");
+    } catch (error) {
+      if (error.response && error.response.status === 401) {
+        throw new Error("Bad credentials");
+      }
+      throw new Error("Internal Server Error");
+    }
+  },
+};

--- a/frontend/store/authentication.js
+++ b/frontend/store/authentication.js
@@ -1,7 +1,7 @@
 const Cookie = process.client ? require("js-cookie") : undefined;
 
 export const state = () => ({
-  access_token: null,
+  accessToken: null,
   client: null,
   id: null,
   uid: null,
@@ -9,7 +9,7 @@ export const state = () => ({
 });
 
 export const getters = {
-  access_token: (state) => state.access_token,
+  accessToken: (state) => state.accessToken,
   client: (state) => state.client,
   uid: (state) => state.uid,
   id: (state) => state.id,
@@ -18,7 +18,7 @@ export const getters = {
 
 export const mutations = {
   clearUser (state) {
-    state.access_token = null;
+    state.accessToken = null;
     state.client = null;
     state.id = null;
     state.uid = null;
@@ -26,7 +26,7 @@ export const mutations = {
   },
 
   setUser (state, res) {
-    state.access_token = res.headers["access-token"];
+    state.accessToken = res.headers["access-token"];
     state.client = res.headers["client"];
     state.id = res.data.data.id;
     state.uid = res.headers["uid"];
@@ -34,7 +34,7 @@ export const mutations = {
   },
 
   setHeader (state, { header, auth_flag }) {
-    state.access_token = header["access-token"];
+    state.accessToken = header["access-token"];
     state.client = header["client"];
     state.uid = header["uid"];
     state.isAuthenticated = auth_flag;
@@ -54,7 +54,7 @@ export const actions = {
       commit("setUser", res);
 
       // Cookieにセット
-      Cookie.set("access-token", getters.access_token);
+      Cookie.set("access-token", getters.accessToken);
       Cookie.set("client", getters.client);
       Cookie.set("uid", getters.uid);
 
@@ -69,7 +69,7 @@ export const actions = {
   // ログアウト
   async logout ({ commit }) {
     try {
-      const access_token = Cookie.get("access-token");
+      const accessToken = Cookie.get("access-token");
       const client = Cookie.get("client");
       const uid = Cookie.get("uid");
 
@@ -77,7 +77,7 @@ export const actions = {
         `/api/v1/auth/sign_out`,
         {
           headers: {
-            "access-token": access_token,
+            "access-token": accessToken,
             client: client,
             uid: uid
           }

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -1,8 +1,8 @@
 const cookieparser = process.server ? require("cookieparser") : undefined;
 
 export const actions = {
-  nuxtServerInit({ commit }, { req }) {
-    if (req.headers.cookie) {
+  nuxtServerInit ({ commit }, { req }) {
+    if (cookieparser !== undefined && req.headers.cookie) {
       const parsed = cookieparser.parse(req.headers.cookie);
       try {
         const auth_flag = parsed.uid ? true : false;

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -1,89 +1,12 @@
 const cookieparser = process.server ? require("cookieparser") : undefined;
 
-export const state = () => ({
-  access_token: null,
-  client: null,
-  id: null,
-  uid: null,
-  isAuthenticated: false,
-});
-
-export const getters = {
-  access_token: (state) => state.access_token,
-  client: (state) => state.client,
-  uid: (state) => state.uid,
-  id: (state) => state.id,
-  isAuthenticated: (state) => state.isAuthenticated,
-};
-
-export const mutations = {
-  clearUser(state) {
-    state.access_token = null;
-    state.client = null;
-    state.id = null;
-    state.uid = null;
-    state.isAuthenticated = false;
-  },
-
-  setUser(state, res) {
-    state.access_token = res.headers["access-token"];
-    state.client = res.headers["client"];
-    state.id = res.data.data.id;
-    state.uid = res.headers["uid"];
-    state.isAuthenticated = true;
-  },
-
-  setHeader(state, { header, auth_flag }) {
-    state.access_token = header["access-token"];
-    state.client = header["client"];
-    state.uid = header["uid"];
-    state.isAuthenticated = auth_flag;
-  }
-};
-
 export const actions = {
-  async login({ commit }, { email, password }) {
-    try {
-      const res = await this.$axios.post(`/api/v1/auth/sign_in`, {
-        email,
-        password
-      })
-
-      commit("setUser", res);
-    } catch (error) {
-      if (error.response && error.response.status === 401) {
-        throw new Error("Bad credentials");
-      }
-      throw new Error("Internal Server Error");
-    }
-  },
-  async logout({ commit }, { access_token, client, uid }) {
-    try {
-      await this.$axios.delete(
-        `/api/v1/auth/sign_out`,
-        {
-          headers: {
-            "access-token": access_token,
-            client: client,
-            uid: uid
-          }
-        }
-      );
-      commit("clearUser");
-    } catch (error) {
-      if (error.response && error.response.status === 401) {
-        throw new Error("Bad credentials");
-      }
-      throw new Error("Internal Server Error");
-    }
-  },
-
   nuxtServerInit({ commit }, { req }) {
     if (req.headers.cookie) {
       const parsed = cookieparser.parse(req.headers.cookie);
       try {
         const auth_flag = parsed.uid ? true : false;
-        commit("setHeader", { header: parsed, auth_flag });
+        commit("authentication/setHeader", { header: parsed, auth_flag });
       } catch (err) {
         // No valid cookie found
       }

--- a/frontend/tests/store/authentication.spec.js
+++ b/frontend/tests/store/authentication.spec.js
@@ -1,0 +1,193 @@
+import Vuex from 'vuex';
+import axios from 'axios';
+import * as authentication from '~/store/authentication';
+import { createLocalVue } from '@vue/test-utils';
+import cloneDeep from 'lodash.clonedeep';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+// axiosのmock
+let mockAxiosGetResult; // Axiosで発生させる戻り値
+let mockAxiosError = false; // Errorを発生させるかどうか
+jest.mock('axios', () => ({
+  post: jest.fn(() => {
+    if (mockAxiosError) {
+      return Promise.reject(mockAxiosGetResult);
+    }
+
+    return Promise.resolve(mockAxiosGetResult);
+  }),
+  delete: jest.fn(() => {
+    if (mockAxiosError) {
+      return Promise.reject(mockAxiosGetResult);
+    }
+
+    return Promise.resolve(mockAxiosGetResult);
+  })
+}));
+
+describe('store/authentication.js', () => {
+  let store;
+
+  // mockのVueインスタンスを生成
+  beforeEach(() => {
+    store = new Vuex.Store(cloneDeep(authentication))
+  })
+
+  describe('mutaions', () => {
+    it('setHeaderの正常系', () => {
+      expect(store.getters.accessToken).toBeNull();
+      expect(store.getters.client).toBeNull();
+      expect(store.getters.uid).toBeNull();
+      expect(store.getters.isAuthenticated).toBeFalsy();
+
+      const parsedCookie = {
+        "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
+        uid: "hoge@example.com",
+        client: "NQqnvItfl_4F9V_l2gzIla",
+      };
+
+      store.commit('setHeader', { header: parsedCookie, auth_flag: true });
+
+      expect(store.getters.accessToken).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
+      expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
+      expect(store.getters.uid).toBe("hoge@example.com");
+      expect(store.getters.isAuthenticated).toBeTruthy();
+    })
+
+    it('setUserとclearUserの正常系', () => {
+      expect(store.getters.accessToken).toBeNull();
+      expect(store.getters.client).toBeNull();
+      expect(store.getters.id).toBeNull();
+      expect(store.getters.uid).toBeNull();
+      expect(store.getters.isAuthenticated).toBeFalsy();
+
+      const res = {
+        headers: {
+          "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
+          uid: "hoge@example.com",
+          client: "NQqnvItfl_4F9V_l2gzIla",
+        },
+        data: { data: { id: "1" } }
+      };
+      store.commit('setUser', res);
+
+      expect(store.getters.accessToken).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
+      expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
+      expect(store.getters.id).toBe("1");
+      expect(store.getters.uid).toBe("hoge@example.com");
+      expect(store.getters.isAuthenticated).toBeTruthy();
+
+      store.commit('clearUser');
+      expect(store.getters.accessToken).toBeNull();
+      expect(store.getters.client).toBeNull();
+      expect(store.getters.id).toBeNull();
+      expect(store.getters.uid).toBeNull();
+      expect(store.getters.isAuthenticated).toBeFalsy();
+    })
+  })
+
+  describe('actions', () => {
+
+    beforeEach(() => {
+      store.$axios = axios; // @nuxtjs/axiosの代わりにaxiosを注入
+      mockAxiosError = false; // テストをする前に、falseに戻す。
+    });
+
+    it('loginできる(正常系)', async () => {
+      mockAxiosGetResult = {
+        headers: {
+          "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
+          uid: "hoge@example.com",
+          client: "NQqnvItfl_4F9V_l2gzIla",
+        },
+        data: { data: { id: "1" } }
+      };
+
+      await store.dispatch('login', { email: 'hoge@example.com', password: 'password' });
+
+      expect(store.getters.accessToken).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
+      expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
+      expect(store.getters.id).toBe("1");
+      expect(store.getters.uid).toBe("hoge@example.com");
+      expect(store.getters.isAuthenticated).toBeTruthy();
+    })
+
+    it('loginできない(異常系:Internal Server Error)', async () => {
+      mockAxiosError = true;
+      mockAxiosGetResult = {
+        reponse: {
+          status: 500
+        }
+      };
+
+      await expect(
+        store.dispatch('login', { email: 'hoge@example.com', password: 'password' })
+      ).rejects.toThrow("Internal Server Error");
+    })
+
+    it('loginできない(異常系:Bad credentials)', async () => {
+      mockAxiosError = true;
+      mockAxiosGetResult = {
+        response: {
+          status: 401
+        }
+      };
+
+      await expect(
+        store.dispatch('login', { email: 'hoge@example.com', password: 'password' })
+      ).rejects.toThrow("Bad credentials");
+    })
+
+    it('logoutできる(正常系)', async () => {
+      const res = {
+        headers: {
+          "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
+          uid: "hoge@example.com",
+          client: "NQqnvItfl_4F9V_l2gzIla",
+        },
+        data: { data: { id: "1" } }
+      };
+      store.commit('setUser', res);
+
+      mockAxiosGetResult = {
+        success: "true"
+      };
+
+      await store.dispatch('logout');
+
+      expect(store.getters.accessToken).toBeNull();
+      expect(store.getters.client).toBeNull();
+      expect(store.getters.id).toBeNull();
+      expect(store.getters.uid).toBeNull();
+      expect(store.getters.isAuthenticated).toBeFalsy();
+    })
+
+    it('logoutできない(異常系:Internal Server Error)', async () => {
+      mockAxiosError = true;
+      mockAxiosGetResult = {
+        reponse: {
+          status: 500
+        }
+      };
+
+      await expect(
+        store.dispatch('logout')
+      ).rejects.toThrow("Internal Server Error");
+    })
+
+    it('logoutできない(異常系:Bad credentials)', async () => {
+      mockAxiosError = true;
+      mockAxiosGetResult = {
+        response: {
+          status: 401
+        }
+      };
+
+      await expect(
+        store.dispatch('logout')
+      ).rejects.toThrow("Bad credentials");
+    })
+  })
+});

--- a/frontend/tests/store/index.spec.js
+++ b/frontend/tests/store/index.spec.js
@@ -37,7 +37,7 @@ describe('store/index.js', () => {
 
   describe('mutaions', () => {
     it('setHeaderの正常系', () => {
-      expect(store.getters.access_token).toBeNull();
+      expect(store.getters.accessToken).toBeNull();
       expect(store.getters.client).toBeNull();
       expect(store.getters.uid).toBeNull();
       expect(store.getters.isAuthenticated).toBeFalsy();
@@ -50,14 +50,14 @@ describe('store/index.js', () => {
 
       store.commit('setHeader', { header: parsedCookie, auth_flag: true });
 
-      expect(store.getters.access_token).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
+      expect(store.getters.accessToken).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
       expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
       expect(store.getters.uid).toBe("hoge@example.com");
       expect(store.getters.isAuthenticated).toBeTruthy();
     })
 
     it('setUserとclearUserの正常系', () => {
-      expect(store.getters.access_token).toBeNull();
+      expect(store.getters.accessToken).toBeNull();
       expect(store.getters.client).toBeNull();
       expect(store.getters.id).toBeNull();
       expect(store.getters.uid).toBeNull();
@@ -73,14 +73,14 @@ describe('store/index.js', () => {
       };
       store.commit('setUser', res);
 
-      expect(store.getters.access_token).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
+      expect(store.getters.accessToken).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
       expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
       expect(store.getters.id).toBe("1");
       expect(store.getters.uid).toBe("hoge@example.com");
       expect(store.getters.isAuthenticated).toBeTruthy();
 
       store.commit('clearUser');
-      expect(store.getters.access_token).toBeNull();
+      expect(store.getters.accessToken).toBeNull();
       expect(store.getters.client).toBeNull();
       expect(store.getters.id).toBeNull();
       expect(store.getters.uid).toBeNull();
@@ -107,7 +107,7 @@ describe('store/index.js', () => {
 
       await store.dispatch('login', { email: 'hoge@example.com', password: 'password'});
 
-      expect(store.getters.access_token).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
+      expect(store.getters.accessToken).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
       expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
       expect(store.getters.id).toBe("1");
       expect(store.getters.uid).toBe("hoge@example.com");
@@ -156,12 +156,12 @@ describe('store/index.js', () => {
       };
 
       await store.dispatch('logout', {
-        access_token: "2RvvBof6HGQ-C__vaMQ5Wq",
+        accessToken: "2RvvBof6HGQ-C__vaMQ5Wq",
         client: "NQqnvItfl_4F9V_l2gzIla",
         uid: 'hoge@example.com'
       });
 
-      expect(store.getters.access_token).toBeNull();
+      expect(store.getters.accessToken).toBeNull();
       expect(store.getters.client).toBeNull();
       expect(store.getters.id).toBeNull();
       expect(store.getters.uid).toBeNull();
@@ -178,7 +178,7 @@ describe('store/index.js', () => {
 
       await expect(
         store.dispatch('logout', {
-          access_token: "2RvvBof6HGQ-C__vaMQ5Wq",
+          accessToken: "2RvvBof6HGQ-C__vaMQ5Wq",
           client: "NQqnvItfl_4F9V_l2gzIla",
           uid: 'hoge@example.com'
         })
@@ -195,7 +195,7 @@ describe('store/index.js', () => {
 
       await expect(
         store.dispatch('logout', {
-          access_token: "2RvvBof6HGQ-C__vaMQ5Wq",
+          accessToken: "2RvvBof6HGQ-C__vaMQ5Wq",
           client: "NQqnvItfl_4F9V_l2gzIla",
           uid: 'hoge@example.com'
         })

--- a/frontend/tests/store/index.spec.js
+++ b/frontend/tests/store/index.spec.js
@@ -18,7 +18,7 @@ describe('store/index.js', () => {
 
     it('nuxtServerInit(正常系)', () => {
       // TODO: cookieparserのテストを書く
-      store.dispatch('nuxtServerInit', { req: null })
+      // store.dispatch('nuxtServerInit', { req: null })
     })
   })
 });

--- a/frontend/tests/store/index.spec.js
+++ b/frontend/tests/store/index.spec.js
@@ -1,31 +1,10 @@
 import Vuex from 'vuex';
-import axios from 'axios';
 import * as index from '~/store/index';
 import { createLocalVue } from '@vue/test-utils';
 import cloneDeep from 'lodash.clonedeep';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-// axiosのmock
-let mockAxiosGetResult; // Axiosで発生させる戻り値
-let mockAxiosError = false; // Errorを発生させるかどうか
-jest.mock('axios', () => ({
-  post: jest.fn(() => {
-    if (mockAxiosError) {
-      return Promise.reject(mockAxiosGetResult);
-    }
-
-    return Promise.resolve(mockAxiosGetResult);
-  }),
-  delete: jest.fn(() => {
-    if (mockAxiosError) {
-      return Promise.reject(mockAxiosGetResult);
-    }
-
-    return Promise.resolve(mockAxiosGetResult);
-  })
-}));
 
 describe('store/index.js', () => {
   let store;
@@ -35,171 +14,11 @@ describe('store/index.js', () => {
     store = new Vuex.Store(cloneDeep(index))
   })
 
-  describe('mutaions', () => {
-    it('setHeaderの正常系', () => {
-      expect(store.getters.accessToken).toBeNull();
-      expect(store.getters.client).toBeNull();
-      expect(store.getters.uid).toBeNull();
-      expect(store.getters.isAuthenticated).toBeFalsy();
-
-      const parsedCookie = {
-        "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
-        uid: "hoge@example.com",
-        client: "NQqnvItfl_4F9V_l2gzIla",
-      };
-
-      store.commit('setHeader', { header: parsedCookie, auth_flag: true });
-
-      expect(store.getters.accessToken).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
-      expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
-      expect(store.getters.uid).toBe("hoge@example.com");
-      expect(store.getters.isAuthenticated).toBeTruthy();
-    })
-
-    it('setUserとclearUserの正常系', () => {
-      expect(store.getters.accessToken).toBeNull();
-      expect(store.getters.client).toBeNull();
-      expect(store.getters.id).toBeNull();
-      expect(store.getters.uid).toBeNull();
-      expect(store.getters.isAuthenticated).toBeFalsy();
-
-      const res = {
-        headers: {
-          "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
-          uid: "hoge@example.com",
-          client: "NQqnvItfl_4F9V_l2gzIla",
-        },
-        data: { data: { id: "1" } }
-      };
-      store.commit('setUser', res);
-
-      expect(store.getters.accessToken).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
-      expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
-      expect(store.getters.id).toBe("1");
-      expect(store.getters.uid).toBe("hoge@example.com");
-      expect(store.getters.isAuthenticated).toBeTruthy();
-
-      store.commit('clearUser');
-      expect(store.getters.accessToken).toBeNull();
-      expect(store.getters.client).toBeNull();
-      expect(store.getters.id).toBeNull();
-      expect(store.getters.uid).toBeNull();
-      expect(store.getters.isAuthenticated).toBeFalsy();
-    })
-  })
-
   describe('actions', () => {
 
-    beforeEach(() => {
-      store.$axios = axios; // @nuxtjs/axiosの代わりにaxiosを注入
-      mockAxiosError = false; // テストをする前に、falseに戻す。
-    });
-
-    it('loginできる(正常系)', async () => {
-      mockAxiosGetResult = {
-        headers: {
-          "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
-          uid: "hoge@example.com",
-          client: "NQqnvItfl_4F9V_l2gzIla",
-        },
-        data: { data: { id: "1" } }
-      };
-
-      await store.dispatch('login', { email: 'hoge@example.com', password: 'password'});
-
-      expect(store.getters.accessToken).toBe("2RvvBof6HGQ-C__vaMQ5Wq");
-      expect(store.getters.client).toBe("NQqnvItfl_4F9V_l2gzIla");
-      expect(store.getters.id).toBe("1");
-      expect(store.getters.uid).toBe("hoge@example.com");
-      expect(store.getters.isAuthenticated).toBeTruthy();
-    })
-
-    it('loginできない(異常系:Internal Server Error)', async () => {
-      mockAxiosError = true;
-      mockAxiosGetResult= {
-        reponse: {
-          status: 500
-        }
-      };
-
-      await expect(
-        store.dispatch('login', { email: 'hoge@example.com', password: 'password'})
-      ).rejects.toThrow("Internal Server Error");
-    })
-
-    it('loginできない(異常系:Bad credentials)', async () => {
-      mockAxiosError = true;
-      mockAxiosGetResult= {
-        response: {
-          status: 401
-        }
-      };
-
-      await expect(
-        store.dispatch('login', { email: 'hoge@example.com', password: 'password'})
-      ).rejects.toThrow("Bad credentials");
-    })
-
-    it('logoutできる(正常系)', async () => {
-      const res = {
-        headers: {
-          "access-token": "2RvvBof6HGQ-C__vaMQ5Wq",
-          uid: "hoge@example.com",
-          client: "NQqnvItfl_4F9V_l2gzIla",
-        },
-        data: { data: { id: "1" } }
-      };
-      store.commit('setUser', res);
-
-      mockAxiosGetResult = {
-        success: "true"
-      };
-
-      await store.dispatch('logout', {
-        accessToken: "2RvvBof6HGQ-C__vaMQ5Wq",
-        client: "NQqnvItfl_4F9V_l2gzIla",
-        uid: 'hoge@example.com'
-      });
-
-      expect(store.getters.accessToken).toBeNull();
-      expect(store.getters.client).toBeNull();
-      expect(store.getters.id).toBeNull();
-      expect(store.getters.uid).toBeNull();
-      expect(store.getters.isAuthenticated).toBeFalsy();
-    })
-
-    it('logoutできない(異常系:Internal Server Error)', async () => {
-      mockAxiosError = true;
-      mockAxiosGetResult= {
-        reponse: {
-          status: 500
-        }
-      };
-
-      await expect(
-        store.dispatch('logout', {
-          accessToken: "2RvvBof6HGQ-C__vaMQ5Wq",
-          client: "NQqnvItfl_4F9V_l2gzIla",
-          uid: 'hoge@example.com'
-        })
-      ).rejects.toThrow("Internal Server Error");
-    })
-
-    it('logoutできない(異常系:Bad credentials)', async () => {
-      mockAxiosError = true;
-      mockAxiosGetResult= {
-        response: {
-          status: 401
-        }
-      };
-
-      await expect(
-        store.dispatch('logout', {
-          accessToken: "2RvvBof6HGQ-C__vaMQ5Wq",
-          client: "NQqnvItfl_4F9V_l2gzIla",
-          uid: 'hoge@example.com'
-        })
-      ).rejects.toThrow("Bad credentials");
+    it('nuxtServerInit(正常系)', () => {
+      // TODO: cookieparserのテストを書く
+      store.dispatch('nuxtServerInit', { req: null })
     })
   })
 });


### PR DESCRIPTION
# やったこと
- 認証系のstoreをauthenticationへ分離
- accesss_tokenをaccessTokenにリネーム
- jestでstoreもcoverageするようにした

storeのテスト内容に変更はない

## 課題
- jestでcookie周りのmockが作れない。
#81 の課題に取り組み、容易にmockを作れるようにすべきであると考える。