### PR TITLE
Multi oauth

### DIFF
--- a/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -1,5 +1,63 @@
 module Api::V1::Auth
   class OmniauthCallbacksController < DeviseTokenAuth::OmniauthCallbacksController
     include Devise::Controllers::Rememberable
+
+    def omniauth_success
+      if current_api_v1_user
+        assign_provider_attrs_for_current_user(current_api_v1_user, auth_hash)
+        current_api_v1_user.save!
+        render json: current_api_v1_user, serializer: UserSerializer
+      else
+        get_resource_from_auth_hash
+        set_token_on_resource
+        create_auth_params
+
+        if confirmable_enabled?
+          # don't send confirmation email!!!
+          @resource.skip_confirmation!
+        end
+
+        sign_in(:user, @resource, store: false, bypass: false)
+
+        @resource.save!
+
+        yield @resource if block_given?
+        render_data_or_redirect('deliverCredentials', @auth_params.as_json, @resource.as_json)
+      end
+    end
+
+    protected
+
+    def assign_provider_attrs(user, auth_hash)
+      attrs = auth_hash['info'].to_hash
+      extra_info = {}
+      extra_info = {
+        "twitter_link" => attrs&.fetch("urls")&.fetch("Twitter", nil)
+      } if auth_hash["provider"] == "twitter"
+      extra_info = {
+        "github_link" => attrs&.fetch("urls")&.fetch("GitHub", nil),
+        "github_token" => auth_hash&.fetch("credentials")&.fetch("token")
+      } if auth_hash["provider"] == "github"
+
+      attrs = attrs.slice(*user.attribute_names)
+      attrs = attrs.merge(extra_info)
+      user.assign_attributes(attrs)
+    end
+
+    def assign_provider_attrs_for_current_user(user, auth_hash)
+      attrs = auth_hash['info'].to_hash
+      extra_info = {}
+      extra_info = {
+        "twitter_link" => attrs&.fetch("urls")&.fetch("Twitter", nil)
+      } if auth_hash["provider"] == "twitter"
+
+      extra_info = {
+        "github_link" => attrs&.fetch("urls")&.fetch("GitHub", nil),
+        "github_token" => auth_hash&.fetch("credentials")&.fetch("token")
+      } if auth_hash["provider"] == "github"
+      
+      user.assign_attributes(extra_info)
+    end
+
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :name, :username, :image, :profile, :address, :created_at, :updated_at
+  attributes :id, :name, :username, :image, :profile, :address, :twitter_link, :github_link, :created_at, :updated_at
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :github,        ENV['GITHUB_KEY'],   ENV['GITHUB_SECRET'],   scope: 'email,profile'
+  provider :github,        ENV['GITHUB_KEY'],   ENV['GITHUB_SECRET'], scope: 'user, repo', provider_ignores_state: true
   provider :twitter,       ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
   provider :google_oauth2, ENV['GOOGLE_KEY'],   ENV['GOOGLE_SECRET']
 end

--- a/db/migrate/20200507060513_add_link_urls_and_github_tokens_to_users.rb
+++ b/db/migrate/20200507060513_add_link_urls_and_github_tokens_to_users.rb
@@ -1,0 +1,13 @@
+class AddLinkUrlsAndGithubTokensToUsers < ActiveRecord::Migration[5.2]
+  def up
+    add_column :users, :twitter_link, :string
+    add_column :users, :github_link, :string
+    add_column :users, :github_token, :string
+  end
+
+  def down
+    remove_column :users, :twitter_link
+    remove_column :users, :github_link
+    remove_column :users, :github_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_05_084802) do
+ActiveRecord::Schema.define(version: 2020_05_07_060513) do
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -48,6 +48,9 @@ ActiveRecord::Schema.define(version: 2020_04_05_084802) do
     t.string "address", limit: 30
     t.string "profile"
     t.string "username", limit: 30
+    t.string "twitter_link"
+    t.string "github_link"
+    t.string "github_token"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/support/omniauth_mocks.rb
+++ b/spec/support/omniauth_mocks.rb
@@ -40,7 +40,10 @@ module OmniauthMocks
           "Github" => "https://github.com/MockUser1234",
           "Website" => ""
         }
-      }
+      },
+      "credentials" => {
+        "token" => "mock_github_token"
+      },
     })
   end
 


### PR DESCRIPTION
やったこと

- Github認証時にgithubアカウントのURLをgithub_urlへ、アクセストークンをgithub_tokenへ格納されるようにした。アクセストークンはリポジトリ作成などの機能が後々実装されるのでそのために必要。

- Twitter認証時にtwitterアカウントのURLがtwitter_urlへ格納されるようにした。

- SNS認証時の処理を非ログイン時とログイン時で分けた。これはデフォルトのdevise token authでは認証とログインがセットになっており、ログインした後に他のサービスと連携すると言ったことができないためである。
今回の変更で、ログイン時はtwitter認証、ログイン後に後からGithub認証を行ってリポジトリ作成などの機能を使う、ということができるようになった。
