### PR TITLE
レスポンスステータスの追加とメッセージの変更

### DIFF
--- a/app/controllers/api/v1/folders_controller.rb
+++ b/app/controllers/api/v1/folders_controller.rb
@@ -46,6 +46,6 @@ class Api::V1::FoldersController < ApplicationController
   def correct_user?
     return if current_api_v1_user == @folder.user
     render status: 401, json: { success: false,
-                                errors: ["アクセスする権限がありません。"] }
+                                errors: ["アクセスする権限がありません"] }
   end
 end

--- a/app/controllers/api/v1/folders_controller.rb
+++ b/app/controllers/api/v1/folders_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::FoldersController < ApplicationController
     if @folder.save
       render json: @folder, serializer: FolderSerializer
     else
-      render json: { status: "error", errors: @folder.errors }
+      render status: :unprocessable_entity, json: @folder.errors
     end
   end
 
@@ -21,13 +21,13 @@ class Api::V1::FoldersController < ApplicationController
     if @folder.update(folder_params)
       render json: @folder, serializer: FolderSerializer
     else
-      render json: { status: "error", errors: @folder.errors }
+      render status: :unprocessable_entity, json: @folder.errors
     end
   end
 
   def destroy
     if @folder.destroy
-      render json: @folder, serializer: FolderSerializer
+      render json: { status: 200, message: "削除に成功しました" }
     else
       render json: { status: "error", errors: @folder.errors }
     end
@@ -45,7 +45,7 @@ class Api::V1::FoldersController < ApplicationController
 
   def correct_user?
     return if current_api_v1_user == @folder.user
-    render json: { success: false,
-                   errors: ["You don't have the right to access this resource"] }
+    render status: 401, json: { success: false,
+                                errors: ["アクセスする権限がありません。"] }
   end
 end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -45,6 +45,6 @@ class Api::V1::PostsController < ApplicationController
   def correct_user?
     return if current_api_v1_user == @post.user
     render status: 401, json: { success: false,
-                   errors: ["アクセスする権限がありません。"] }
+                   errors: ["アクセスする権限がありません"] }
   end
 end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::PostsController < ApplicationController
     if @post.save
       render json: @post, serializer: PostSerializer
     else
-      render json: { status: "error", errors: @post.errors }
+      render status: :unprocessable_entity, json: @post.errors
     end
   end
 
@@ -20,13 +20,13 @@ class Api::V1::PostsController < ApplicationController
     if @post.update(post_params)
       render json: @post, serializer: PostSerializer
     else
-      render json: { status: "error", errors: @post.errors }
+      render  status: :unprocessable_entity, json: @post.errors
     end
   end
 
   def destroy
     if @post.destroy
-      render json: @post, serializer: PostSerializer
+      render json: { status: 200, message: "削除に成功しました" }
     else
       render json: { status: "error", errors: @post.errors }
     end
@@ -44,7 +44,7 @@ class Api::V1::PostsController < ApplicationController
 
   def correct_user?
     return if current_api_v1_user == @post.user
-    render json: { success: false,
-                   errors: ["You don't have the right to access this resource"] }
+    render status: 401, json: { success: false,
+                   errors: ["アクセスする権限がありません。"] }
   end
 end

--- a/spec/requests/api/v1/folders_spec.rb
+++ b/spec/requests/api/v1/folders_spec.rb
@@ -99,11 +99,15 @@ RSpec.describe "Api::V1::Folders", type: :request do
         }
       end
 
+      it 'レスポンスステータスが200で返ること' do
+        call_api
+        expect(response.status).to eq 422
+      end
+
       it 'バリデーションエラーが返ること' do
         call_api
         res = JSON.parse(response.body)
-        expect(res["status"]).to eq "error"
-        expect(res["errors"]["name"]).to eq ["を入力してください"]
+        expect(res["name"]).to eq ["を入力してください"]
       end
     end
   end
@@ -154,11 +158,15 @@ RSpec.describe "Api::V1::Folders", type: :request do
           }
         end
 
+        it 'レスポンスステータスが200で返ること' do
+          call_api
+          expect(response.status).to eq 422
+        end
+
         it 'バリデーションエラーが返ること' do
           call_api
           res = JSON.parse(response.body)
-          expect(res["status"]).to eq "error"
-          expect(res["errors"]["name"]).to eq ["を入力してください"]
+          expect(res["name"]).to eq ["を入力してください"]
         end
       end
     end
@@ -170,7 +178,7 @@ RSpec.describe "Api::V1::Folders", type: :request do
           call_api
           res = JSON.parse(response.body)
           expect(res["success"]).to eq false
-          expect(res["errors"]).to eq ["You don't have the right to access this resource"]
+          expect(res["errors"]).to eq ["アクセスする権限がありません。"]
         end
     end
   end
@@ -197,9 +205,7 @@ RSpec.describe "Api::V1::Folders", type: :request do
         it "レスポンスボディーに期待された値が返ること" do
           call_api
           res = JSON.parse(response.body)
-          expect(res["data"]["attributes"]["name"]).to eq "folder_test"
-          expect(res["data"]["attributes"]["public"]).to eq false
-          expect(res["data"]["attributes"]["user-id"]).to eq user.id
+          expect(res['message']).to eq "削除に成功しました"
         end
       end
     end
@@ -211,7 +217,7 @@ RSpec.describe "Api::V1::Folders", type: :request do
          call_api
          res = JSON.parse(response.body)
          expect(res["success"]).to eq false
-         expect(res["errors"]).to eq ["You don't have the right to access this resource"]
+         expect(res["errors"]).to eq ["アクセスする権限がありません。"]
        end
     end
   end

--- a/spec/requests/api/v1/folders_spec.rb
+++ b/spec/requests/api/v1/folders_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe "Api::V1::Folders", type: :request do
           call_api
           res = JSON.parse(response.body)
           expect(res["success"]).to eq false
-          expect(res["errors"]).to eq ["アクセスする権限がありません。"]
+          expect(res["errors"]).to eq ["アクセスする権限がありません"]
         end
     end
   end
@@ -217,7 +217,7 @@ RSpec.describe "Api::V1::Folders", type: :request do
          call_api
          res = JSON.parse(response.body)
          expect(res["success"]).to eq false
-         expect(res["errors"]).to eq ["アクセスする権限がありません。"]
+         expect(res["errors"]).to eq ["アクセスする権限がありません"]
        end
     end
   end

--- a/spec/requests/api/v1/posts_spec.rb
+++ b/spec/requests/api/v1/posts_spec.rb
@@ -123,12 +123,16 @@ RSpec.describe "Api::V1::Posts", type: :request do
         }
       end
 
+      it 'レスポンスステータスが200で返ること' do
+        call_api
+        expect(response.status).to eq 422
+      end
+
       it 'バリデーションエラーが返ること' do
         call_api
         res = JSON.parse(response.body)
-        expect(res["status"]).to eq "error"
-        expect(res["errors"]["name"]).to eq ["を入力してください"]
-        expect(res["errors"]["content"]).to eq ["を入力してください"]
+        expect(res["name"]).to eq ["を入力してください"]
+        expect(res["content"]).to eq ["を入力してください"]
       end
     end
   end
@@ -216,12 +220,16 @@ RSpec.describe "Api::V1::Posts", type: :request do
           }
         end
 
+        it 'レスポンスステータスが200で返ること' do
+          call_api
+          expect(response.status).to eq 422
+        end
+
         it 'バリデーションエラーが返ること' do
           call_api
           res = JSON.parse(response.body)
-          expect(res["status"]).to eq "error"
-          expect(res["errors"]["name"]).to eq ["を入力してください"]
-          expect(res["errors"]["content"]).to eq ["を入力してください"]
+          expect(res["name"]).to eq ["を入力してください"]
+          expect(res["content"]).to eq ["を入力してください"]
         end
       end
     end
@@ -233,7 +241,7 @@ RSpec.describe "Api::V1::Posts", type: :request do
         call_api
         res = JSON.parse(response.body)
         expect(res["success"]).to eq false
-        expect(res["errors"]).to eq ["You don't have the right to access this resource"]
+        expect(res["errors"]).to eq ["アクセスする権限がありません。"]
       end
     end
   end
@@ -262,11 +270,7 @@ RSpec.describe "Api::V1::Posts", type: :request do
         it "レスポンスボディーに期待された値が返ること" do
           call_api
           res = JSON.parse(response.body)
-          expect(res["data"]["attributes"]["name"]).to eq "test"
-          expect(res["data"]["attributes"]["content"]).to eq "example"
-          expect(res["data"]["attributes"]["public"]).to eq false
-          expect(res["data"]["attributes"]["user-id"]).to eq user.id
-          expect(res["data"]["attributes"]["folder-id"]).to eq folder.id
+          expect(res['message']).to eq "削除に成功しました"
         end
       end
     end
@@ -278,7 +282,7 @@ RSpec.describe "Api::V1::Posts", type: :request do
          call_api
          res = JSON.parse(response.body)
          expect(res["success"]).to eq false
-         expect(res["errors"]).to eq ["You don't have the right to access this resource"]
+         expect(res["errors"]).to eq ["アクセスする権限がありません。"]
        end
     end
   end

--- a/spec/requests/api/v1/posts_spec.rb
+++ b/spec/requests/api/v1/posts_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe "Api::V1::Posts", type: :request do
         call_api
         res = JSON.parse(response.body)
         expect(res["success"]).to eq false
-        expect(res["errors"]).to eq ["アクセスする権限がありません。"]
+        expect(res["errors"]).to eq ["アクセスする権限がありません"]
       end
     end
   end
@@ -282,7 +282,7 @@ RSpec.describe "Api::V1::Posts", type: :request do
          call_api
          res = JSON.parse(response.body)
          expect(res["success"]).to eq false
-         expect(res["errors"]).to eq ["アクセスする権限がありません。"]
+         expect(res["errors"]).to eq ["アクセスする権限がありません"]
        end
     end
   end


### PR DESCRIPTION
##　行った事

- folder,postのvalidaionエラーのレスポンスステータス422返すように設定

- folder,postのログインユーザー有無のメソッドのレスポンスステータス401返すように設定

- エラー文の日本語化

- 削除時のエラー文の設定
