### PR TITLE
feat StoreでUserInfoを管理できるようにした

### DIFF
--- a/frontend/components/organisms/cards/SettingProfileCard.vue
+++ b/frontend/components/organisms/cards/SettingProfileCard.vue
@@ -5,18 +5,19 @@
 </template>
 
 <script>
+import User from "@/types/User"
 const EditProfileForm = () => import('~/components/organisms/form/EditProfileForm')
 
 export default {
-  props: {
-    info: {
-      type: Object,
-      default: undefined
-    }
-  },
-
   components: {
     EditProfileForm
+  },
+
+  props: {
+    info: {
+      type: User,
+      default: undefined
+    }
   },
 
   methods: {

--- a/frontend/components/organisms/form/EditProfileForm.vue
+++ b/frontend/components/organisms/form/EditProfileForm.vue
@@ -69,12 +69,15 @@ export default {
   },
 
   created() {
-    // this.form.address = this.info.address
+    this.form.address = this.info.address
     this.form.profile = this.info.profile
     this.form.name = this.info.name
   },
 
   computed: {
+    /**
+     * @returns {String}
+     */
     getPreviewIcon() {
       return this.form.avatar || this.info.image || 'https://picsum.photos/510/300?random'
     }

--- a/frontend/components/organisms/form/EditProfileForm.vue
+++ b/frontend/components/organisms/form/EditProfileForm.vue
@@ -4,7 +4,7 @@
       <p>プロフィール画像</p>
       <div class="d-flex align-center">
         <div class="mr-2">
-          <v-img :src="user.avatar" class="user-icon" />
+          <v-img :src="getPreviewIcon" class="user-icon" />
         </div>
 
         <preview-image-file-input @input="setAvatarValue" />
@@ -16,17 +16,17 @@
     <!-- TODO(Ropital): 各divをコンポーネントに切り出す -->
     <div class="mb-8">
       <p>名前</p>
-      <v-text-field v-model="user.name" label="名前" outlined dense />
+      <v-text-field v-model="form.name" label="名前" outlined dense />
     </div>
 
     <div class="mb-8">
       <p>自己紹介</p>
-      <v-textarea v-model="user.profile" label="自己紹介" outlined height="80" />
+      <v-textarea v-model="form.profile" label="自己紹介" outlined height="80" />
     </div>
 
     <div class="mb-8">
       <p>出身</p>
-      <v-text-field v-model="user.address" label="出身" outlined dense />
+      <v-text-field v-model="form.address" label="出身" outlined dense />
     </div>
 
     <tie-sns-link-field />
@@ -38,55 +38,55 @@
 </template>
 
 <script>
+import User from "@/types/User"
 const PreviewImageFileInput = () => import('~/components/organisms/fileInputs/PreviewImageFileInput')
 const TieSnsLinkField = () => import('~/components/organisms/textFields/TieSnsLinkField')
 const OrangeBtn = () => import('~/components/atoms/btns/OrangeBtn')
 
-class UserInfo {
-  constructor() {
-      this.name = null
-      this.profile = null
-      this.address = null
-      this.avatar = "https://picsum.photos/510/300?random"
-  }
-
-  infoToUserInfo(info) {
-    this.name = info && info.attributes && info.attributes.name
-    this.profile = info && info.attributes && info.attributes.profile
-    this.address = info && info.attributes && info.attributes.address
-    // Todo: avatarを取得する
-  }
-}
-
 export default {
-  props: {
-    info: {
-      type: Object,
-      default: undefined
-    }
-  },
-
   components: {
     PreviewImageFileInput,
     TieSnsLinkField,
     OrangeBtn
   },
 
-  data: () => ({
-      user: new UserInfo
-  }),
+  props: {
+    info: {
+      type: User,
+      default: undefined
+    }
+  },
+
+  data() {
+    return {
+      form: {
+        address: '',
+        avatar: null,
+        profile: '',
+        name: '',
+      }
+    }
+  },
 
   created() {
-    this.user.infoToUserInfo(this.info)
+    // this.form.address = this.info.address
+    this.form.profile = this.info.profile
+    this.form.name = this.info.name
+  },
+
+  computed: {
+    getPreviewIcon() {
+      return this.form.avatar || this.info.image || 'https://picsum.photos/510/300?random'
+    }
   },
 
   methods: {
     onClick() {
-      this.$emit('save', this.user)
+      this.$emit('save', this.form)
     },
 
     setAvatarValue(newVal) {
-      this.user.avatar = newVal
+      this.form.avatar = newVal
     }
   }
 }

--- a/frontend/components/templates/SettingProfileTemplate.vue
+++ b/frontend/components/templates/SettingProfileTemplate.vue
@@ -7,13 +7,14 @@
 </template>
 
 <script>
+import User from "@/types/User"
 import OneColumnContainer from '~/components/molecules/containers/OneColumnContainer'
 import SettingProfileCard from '~/components/organisms/cards/SettingProfileCard'
 
 export default {
   props: {
     info: {
-      type: Object,
+      type: User,
       default: undefined
     }
   },

--- a/frontend/middleware/check-auth.js
+++ b/frontend/middleware/check-auth.js
@@ -1,9 +1,9 @@
-// export default async ({ store, req }) => {
-//   // ログイン状態でuserInfoがないとき、取得する
-//   if (
-//     store.getters["authentication/isAuthenticated"] &&
-//     !store.getters["authentication/userInfo"]
-//   ) {
-//     await store.dispatch("authentication/fetchUser")
-//   }
-// }
+export default async ({ store }) => {
+  // ログイン状態でuserInfoがないとき、取得する
+  if (
+    store.getters["authentication/isAuthenticated"] &&
+    !store.getters["authentication/userInfo"]
+  ) {
+    await store.dispatch("authentication/fetchUser")
+  }
+}

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -61,9 +61,9 @@ module.exports = {
    */
   css: [{ src: "~/assets/sass/app.scss", lang: "scss" }],
 
-  // router: {
-  //   middleware: ["check-auth"],
-  // },
+  router: {
+    middleware: ["check-auth"],
+  },
 
   /*
    ** Axios configuration

--- a/frontend/pages/settings/profile.vue
+++ b/frontend/pages/settings/profile.vue
@@ -14,38 +14,25 @@ export default {
 
   middleware: "authenticated",
 
-  // TODO: storeから取れるので、あとで削除する
-  async asyncData({ $axios, store }) {
-    try {
-      const { data } = await $axios.$get(`/api/v1/auth/edit`,
-      {
-        headers: {
-          "access-token": store.getters["authentication/accessToken"],
-          "client": store.getters["authentication/client"],
-          "uid": store.getters["authentication/uid"]
-        }
-      })
-      return { info: data }
-    } catch (e) {
-      console.error(e)
+  computed: {
+    info() {
+      return this.$store.getters['authentication/userInfo']
     }
   },
 
-  computed: {
-    // TODO: infoをstoreから取得する
-    // info() {
-    //   return this.$store.getters['authentication/userInfo']
-    // }
-  },
-
   methods: {
+
+    /**
+     * @param {import('~/types/User').default} userInfo
+     */
     async save(userInfo) {
       try {
         await this.$axios.put(`/api/v1/auth`, {
           name: userInfo.name,
           profile: userInfo.profile,
           address: userInfo.address,
-          avatar: userInfo.avatar
+          avatar: userInfo.avatar,
+          image: userInfo.image
         })
       } catch (e) {
         console.error(e)

--- a/frontend/plugins/axios.js
+++ b/frontend/plugins/axios.js
@@ -1,7 +1,9 @@
-export default ({ app: { $axios }, store }) => {
+export default ({ $axios , store }) => {
   $axios.onRequest(config => {
-    $axios.setHeader("access-token", store.getters["authentication/accessToken"])
-    $axios.setHeader("uid", store.getters["authentication/uid"])
-    $axios.setHeader("client", store.getters["authentication/client"])
+    if (store.getters["authentication/isAuthenticated"]) {
+      config.headers.common["access-token"] = store.getters["authentication/accessToken"]
+      config.headers.common["uid"] = store.getters["authentication/uid"]
+      config.headers.common["client"] = store.getters["authentication/client"]
+    }
   })
 }

--- a/frontend/store/authentication.js
+++ b/frontend/store/authentication.js
@@ -1,6 +1,20 @@
 import Cookies from "universal-cookie"
+import User from "~/types/User"
 const cookies = new Cookies()
 
+/**
+ * @typedef state
+ * @property {String} accessToken
+ * @property {String} client
+ * @property {Number} id
+ * @property {String} uid - UserId
+ * @property {String} username - ユーザー名
+ * @property {User} userInfo
+ */
+
+/**
+ * @returns {state}
+ */
 export const state = () => ({
   accessToken: null,
   client: null,
@@ -30,13 +44,13 @@ export const mutations = {
     state.userInfo = null
   },
 
-  setUser (state, res) {
-    state.accessToken = res.headers["access-token"]
-    state.client = res.headers["client"]
-    state.id = res.data.data.id
-    state.uid = res.headers["uid"]
-    state.username = res.data.data.attributes.username
-    state.userInfo = res.data.data
+  setUser (state, { headers, data }) {
+    state.accessToken = headers["access-token"]
+    state.client = headers["client"]
+    state.id = data.data.id
+    state.uid = headers["uid"]
+    state.username = data.data.attributes.username
+    state.userInfo = new User(data.data)
   },
 
   setUserInfo (state, userInfo) {
@@ -61,18 +75,18 @@ export const actions = {
    *
    * TODO: 動くかは確認してないので、確認する
    */
-  // async fetchUser ({ commit, getters }) {
-  //   try {
-  //     const { data } = await this.$axios.$get(`users/${getters.id}`)
+  async fetchUser ({ commit, getters }) {
+    try {
+      const { data } = await this.$axios.$get(`/api/v1/users/${getters.username}`)
 
-  //     commit('setUserInfo', data)
-  //   } catch (e) {
-  //     if (e.response && e.response.status === 401) {
-  //       throw new Error("Bad credentials")
-  //     }
-  //     throw new Error("Internal Server Error")
-  //   }
-  // },
+      commit('setUserInfo', new User(data))
+    } catch (e) {
+      if (e.response && e.response.status === 401) {
+        throw new Error("Bad credentials")
+      }
+      throw new Error("Internal Server Error")
+    }
+  },
 
   // ログイン
   async login ({ commit, getters }, { email, password }) {

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -1,11 +1,13 @@
 import Cookies from 'universal-cookie'
 
 export const actions = {
-  nuxtServerInit ({ commit }, { req }) {
+  async nuxtServerInit ({ commit }, { req }) {
     if (req.headers.cookie) {
       try {
         const { cookies } = new Cookies(req.headers.cookie)
+
         commit("authentication/setHeader", { headers: cookies })
+        await store.dispatch("authentication/fetchUser")
       } catch (err) {
         // No valid cookie found
       }

--- a/frontend/types/User.js
+++ b/frontend/types/User.js
@@ -1,0 +1,37 @@
+/**
+ * @typedef UserAttributes
+ * @property {String} address
+ * @property {String} created-at
+ * @property {String} github-link
+ * @property {String} image
+ * @property {String} name
+ * @property {String} profile
+ * @property {String} twitter-link
+ * @property {String} updated-at
+ * @property {String} username
+ */
+
+/**
+ * @class User
+ */
+class User {
+
+  /**
+   * @param {{ id: String, type: String, attributes: UserAttributes }} obj
+   */
+  constructor({ id, type, attributes }) {
+    this.id = id
+    this.type = type
+    this.address = attributes.address
+    this.createdAt = new Date(attributes['created-at'])
+    this.githubLink = attributes['github-link']
+    this.image = attributes.image
+    this.name = attributes.name
+    this.profile = attributes.profile
+    this.twitterLink = attributes['twitter-link']
+    this.updatedAt = new Date(attributes['updated-at'])
+    this.username = attributes.username
+  }
+}
+
+export default User

--- a/frontend/utils/string.js
+++ b/frontend/utils/string.js
@@ -1,7 +1,7 @@
 /**
  * キャメルケースへ変換 sampleString
- * @param string
- * @return string
+ * @param {String} str
+ * @return String
  */
 export const camelCase = (str) => {
   str = str.charAt(0).toLowerCase() + str.slice(1)
@@ -13,8 +13,8 @@ export const camelCase = (str) => {
 
 /**
  * スネークケースへ変換 sample_string
- * @param string
- * @return string
+ * @param {String} str
+ * @return String
  */
 export const snakeCase = (str) => {
   const camel = camelCase(str)
@@ -26,8 +26,8 @@ export const snakeCase = (str) => {
 
 /**
  * パスカルケースへ変換 SampleString
- * @param string
- * @return string
+ * @param {String} str
+ * @return String
  */
 export const pascalCase = (str) => {
   const camel = camelCase(str)


### PR DESCRIPTION
# やったこと
- storeでUserInfoを管理できるようにした
- User型の追加
APIのUserInfoを直接代入するとIDEの補完が効かず、開発しにくいから。