### PR TITLE
design デザインを修正

### DIFF
--- a/frontend/assets/sass/overwrite.scss
+++ b/frontend/assets/sass/overwrite.scss
@@ -2,6 +2,7 @@
  *ライブラリのCSSの上書きを記載
  */
 
+
 /**
  * Mavon Editor
  *
@@ -24,5 +25,18 @@
     @include mq(sm) {
       max-width: 30%;
     }
+  }
+}
+
+.markdown-body {
+  pre {
+    font-size: 1rem;
+  }
+
+  code {
+    box-shadow: none;
+    color: #333;
+    background-color: rgba(27, 31, 35, 0.05);
+    padding: 0.2em 0;
   }
 }

--- a/frontend/components/organisms/list/LinkToBackItem.vue
+++ b/frontend/components/organisms/list/LinkToBackItem.vue
@@ -1,9 +1,16 @@
 <template>
-  <v-list-item :to="to">
-    <v-list-item-icon>
-      <v-icon>mdi-arrow-left-circle</v-icon>
-    </v-list-item-icon>
-  </v-list-item>
+  <v-row>
+    <v-col cols="11" class="pa-0">
+      <v-list-item :to="to" exact>
+        <v-list-item-icon>
+          <v-icon>mdi-arrow-left-circle</v-icon>
+        </v-list-item-icon>
+        <v-list-item-content>
+          <v-list-item-title />
+        </v-list-item-content>
+      </v-list-item>
+    </v-col>
+  </v-row>
 </template>
 
 <script>

--- a/frontend/components/organisms/list/OtherPostList.vue
+++ b/frontend/components/organisms/list/OtherPostList.vue
@@ -1,0 +1,67 @@
+<template>
+  <article v-if="postList">
+    <h2 class="main-heading mb-8 text-center">ほかの投稿を見る</h2>
+
+    <v-card v-for="(post, key) in getPostList" :key="key" class="mb-4">
+      <v-card-text>
+        <span class="main-heading card-title-font">{{ post.name }}</span>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-spacer />
+
+        <v-btn
+          :to="getLink(post)"
+          text
+          color="deep-purple accent-4"
+        >
+          投稿を見る
+        </v-btn>
+    </v-card-actions>
+    </v-card>
+  </article>
+</template>
+
+<script>
+export default {
+  props: {
+    userInfo: {
+      type: Object,
+      default: undefined
+    },
+
+    postList: {
+      type: Array,
+      default: undefined
+    }
+  },
+
+  computed: {
+    getLink() {
+      return (post) => {
+        let link = ""
+        for (const ancestorFolder of post.ancestorFolders) {
+          link += `/${ancestorFolder.id}`
+        }
+
+        link += `/${post.uid}`
+        return `/${this.userInfo.username}${link}`
+      }
+    },
+
+    getPostList() {
+      if (!this.postList) {
+        return undefined
+      }
+
+      return this.postList.filter((post) => this.getLink(post) !== this.$route.path)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.card-title-font {
+  font-size: 1.1rem;
+}
+</style>

--- a/frontend/components/templates/EditPostSuccessTemplate.vue
+++ b/frontend/components/templates/EditPostSuccessTemplate.vue
@@ -42,7 +42,7 @@ export default {
     },
 
     hashtag() {
-      return "til,poeta,駆け出しエンジニアとつながりたい"
+      return "til,poeta,駆け出しエンジニアと繋がりたい"
     },
 
     getViewLink() {

--- a/frontend/components/templates/EditPostTemplate.vue
+++ b/frontend/components/templates/EditPostTemplate.vue
@@ -1,10 +1,9 @@
 <template>
   <OneColumnContainer class="pos-relative" fluid>
     <v-row>
-      <v-col class="py-0" cols="12" sm="6" md="3">
-        <PostNameTextField v-model="nameModel" rounded outlined />
+      <v-col class="py-0 mr-sm-4" cols="12" sm="6" md="3">
+        <PostNameTextField v-model="nameModel" outlined />
       </v-col>
-      <v-spacer />
       <v-col class="py-0" cols="12" sm="3" md="3">
         <v-switch v-model="pubModel" class="mt-0 mt-sm-2" color="primary" flat :label="`${pub ? '公開' : '非公開'}`" />
       </v-col>

--- a/frontend/components/templates/UsernameFolderTemplate.vue
+++ b/frontend/components/templates/UsernameFolderTemplate.vue
@@ -14,7 +14,7 @@
       <v-container>
         <v-row>
           <v-col cols="12" sm="8">
-            <h2 class="text-center">{{ canAction ? 'あなた' : currentUsername }}のリポジトリ</h2>
+            <h2 class="text-center">{{ canAction ? 'あなた' : currentName }}のフォルダ</h2>
           </v-col>
           <v-col v-if="canAction" cols="12" sm="4" class="text-right">
             <BlueBtn @click="onTriggerCreatingNewFolder" class="mb-4">フォルダーを作成する</BlueBtn>
@@ -65,10 +65,10 @@
 /**
  * パンくずリストの作成
  */
-const generateBreadcrumbs = (username, ancestorFolders) => {
+const generateBreadcrumbs = (username, displayName, ancestorFolders) => {
   let pastLink = `/${username}`
 
-  const rootBreadCrumbs = [{ to: pastLink, name: `${username}` }]
+  const rootBreadCrumbs = [{ to: pastLink, name: `${displayName}` }]
   const reAncestorFolders = Object.assign([], ancestorFolders).reverse()
 
   const ancestorBreadCrumbs = reAncestorFolders.map(
@@ -139,7 +139,7 @@ export default {
      * @returns { { to: Number , name: String }[] }
      */
     breadCrumbs() {
-      return generateBreadcrumbs(this.currentUsername, this.ancestorFolders)
+      return generateBreadcrumbs(this.currentUsername, this.currentName, this.ancestorFolders)
     },
 
     /**
@@ -151,6 +151,13 @@ export default {
       }
 
       return this.foldersInfo.name
+    },
+
+    /**
+     * 現在アクセスしているユーザーの名前
+     */
+    currentName() {
+      return this.userInfo.name || this.currentUsername
     },
 
     /**

--- a/frontend/components/templates/UsernamePostTemplate.vue
+++ b/frontend/components/templates/UsernamePostTemplate.vue
@@ -1,16 +1,11 @@
 <template>
   <TwoColumnContainer
     :left-cols="12"
-    :left-sm="4"
+    :left-sm="8"
     :rightCols="12"
-    :right-sm="8"
-    bottom-class="flex-column-reverse flex-sm-row"
+    :right-sm="4"
   >
     <template #left>
-      <UserIntroCard :userInfo="userInfo" />
-    </template>
-
-    <template #right>
       <div class="mb-6">
         <h1 class="mb-4">{{ postInfo.name }}</h1>
 
@@ -22,6 +17,14 @@
           編集する
         </BlueBtn>
       </v-row>
+    </template>
+
+    <template #right>
+      <div class="mb-4">
+        <UserIntroCard :userInfo="userInfo" />
+      </div>
+
+      <OtherPostList :userInfo="userInfo" :postList="userInfo.posts" />
     </template>
   </TwoColumnContainer>
 </template>


### PR DESCRIPTION
# やったこと
- TILのユーザー紹介のカードを右に持っていく。そして、その下にほかの投稿を表示する。
- 戻るボタンは動かないように
- markdownのコード`<code>`の影をなくす
- ファイル名は四角。公開・非公開はファイル名の横
- 駆け出しエンジニアと繋がりたいにtwitterのタグを変更
- 「あなたのリポジトリ」を「あなたのフォルダ」。他人の名前のデフォルトを「ユーザーが設定した名前にする」

## 別で考えるつもり、どうしよう
「ほかの投稿を見る」のデータ取得の仕方があまりよくないので、取得データは後で差し替えたい。APIを別で設けないとダメかなーと思う。
デザインもどうしようかなーという感じです。ファイル名だけだと寂しいような気もする。ただ、マークダウンを使うのも処理量的につらいなーと思う。ここはファイルに一言コメントをつけられるようにすべきなのかなと思ったりする。

## スクリーンショット
![コメント 2020-07-12 213220](https://user-images.githubusercontent.com/46477357/87246349-d2885300-c487-11ea-8015-f8e2ebd6a771.png)
![コメント 2020-07-12 213727](https://user-images.githubusercontent.com/46477357/87246363-e7fd7d00-c487-11ea-9170-145c9cd7c7c9.png)
