### PR TITLE
SNS認証周りの処理

### DIFF
--- a/frontend/components/organisms/btnGroup/UserSnsBtnGroup.vue
+++ b/frontend/components/organisms/btnGroup/UserSnsBtnGroup.vue
@@ -1,21 +1,31 @@
 <template>
   <div>
     <!-- 各ユーザーのsnsへのリンク -->
-    <TwitterBtn fab v-if="twitterLinkIsExists"/>
-    <GithubBtn fab v-if="githubLinkIsExists"/>
+    <TwitterBtn fab v-if="twitterLinkIsExists" :href="twitterLink" depressed />
+    <GithubBtn fab v-if="githubLinkIsExists" :href="githubLink" depressed />
   </div>
 </template>
 
 <script>
 export default {
+  props: {
+    twitterLink: {
+      type: String,
+      default: '',
+    },
+
+    githubLink: {
+      type: String,
+      default: '',
+    },
+  },
+
   computed: {
     twitterLinkIsExists() {
-      // TODO(Ropital): Twitterリンクが存在したらtrueを返す
-      return false
+      return !!this.twitterLink
     },
     githubLinkIsExists() {
-      // TODO(Ropital): Githubリンクが存在したらtrueを返す
-      return false
+      return !!this.githubLink
     },
   }
 }

--- a/frontend/components/organisms/cards/UserIntroCard.vue
+++ b/frontend/components/organisms/cards/UserIntroCard.vue
@@ -54,7 +54,6 @@ export default {
     },
 
     getTwitterLink() {
-      console.log(this.userInfo)
       return this.userInfo.twitterLink
     },
 

--- a/frontend/components/organisms/cards/UserIntroCard.vue
+++ b/frontend/components/organisms/cards/UserIntroCard.vue
@@ -17,7 +17,7 @@
         </p>
 
         <v-btn v-if="canLookFolderPath" :to="`/${username}`" text color="primary">{{ getName }}のページを見る</v-btn>
-        <UserSnsBtnGroup />
+        <UserSnsBtnGroup :twitterLink="getTwitterLink" :githubLink="getGithubLink" />
       </div>
     </div>
   </v-card>
@@ -51,6 +51,15 @@ export default {
 
     getAvatar() {
       return this.userInfo && this.userInfo.image
+    },
+
+    getTwitterLink() {
+      console.log(this.userInfo)
+      return this.userInfo.twitterLink
+    },
+
+    getGithubLink() {
+      return this.userInfo.githubLink
     },
 
     username() {

--- a/frontend/pages/auth/oauth.vue
+++ b/frontend/pages/auth/oauth.vue
@@ -8,7 +8,28 @@ export default {
     const { auth_token, client_id, id, uid, username } = this.$route.query
     const userInfo = { authToken: auth_token, clientId: client_id, id, uid, username }
     this.$store.dispatch("authentication/loginWithSns", { userInfo })
-    this.$router.push('/settings/profile')
+    const redirectPath = this.redirectPath
+    this.setFromSecondTimeLogin()
+    this.$router.push(redirectPath)
+  },
+
+  computed: {
+    redirectPath() {
+        const isFromSecondTimeLogin = window.localStorage.getItem('isFromSecondTimeLogin')
+        return isFromSecondTimeLogin !== 'true' ? '/settings/user-name' : '/settings/profile'
+    }
+  },
+
+  methods: {
+    /**
+     * 2回目以降のログイン判定のために、
+     * ローカルストレージに判定用の値({ 'isFromSecondTimeLogin': 'true' })を入れる
+     */
+    setFromSecondTimeLogin() {
+      if (window.localStorage) {
+        window.localStorage.setItem('isFromSecondTimeLogin', 'true')
+      }
+    }
   }
 }
 </script>

--- a/frontend/pages/auth/oauth.vue
+++ b/frontend/pages/auth/oauth.vue
@@ -15,8 +15,12 @@ export default {
 
   computed: {
     redirectPath() {
+      if (window.localStorage) {
         const isFromSecondTimeLogin = window.localStorage.getItem('isFromSecondTimeLogin')
         return isFromSecondTimeLogin !== 'true' ? '/settings/user-name' : '/settings/profile'
+      } else {
+        return '/settings/profile'
+      }
     }
   },
 

--- a/frontend/pages/auth/oauth.vue
+++ b/frontend/pages/auth/oauth.vue
@@ -3,6 +3,9 @@
 </template>
 
 <script>
+const key = 'isFromSecondTimeLogin'
+const value = 'true'
+
 export default {
   created() {
     const { auth_token, client_id, id, uid, username } = this.$route.query
@@ -16,8 +19,8 @@ export default {
   computed: {
     redirectPath() {
       if (window.localStorage) {
-        const isFromSecondTimeLogin = window.localStorage.getItem('isFromSecondTimeLogin')
-        return isFromSecondTimeLogin !== 'true' ? '/settings/user-name' : '/settings/profile'
+        const isFromSecondTimeLogin = window.localStorage.getItem(key)
+        return isFromSecondTimeLogin !== value ? '/settings/user-name' : '/settings/profile'
       } else {
         return '/settings/profile'
       }
@@ -31,7 +34,7 @@ export default {
      */
     setFromSecondTimeLogin() {
       if (window.localStorage) {
-        window.localStorage.setItem('isFromSecondTimeLogin', 'true')
+        window.localStorage.setItem(key, value)
       }
     }
   }

--- a/frontend/pages/signup/index.vue
+++ b/frontend/pages/signup/index.vue
@@ -46,7 +46,7 @@ export default {
     },
 
     async snsauth(provider) {
-      document.location.href = `${process.env.baseUrl}/api/v1/auth/${provider}`
+      document.location.href = `${this.$config.baseUrl}/api/v1/auth/${provider}`
     }
   },
 


### PR DESCRIPTION
# やったこと
- SNS認証した後、初回時にusername編集画面へ遷移するよう変更
- Signupページからsnsでログインできるように
- SNS認証時に、SNSボタンがマイページで表示されるように